### PR TITLE
Docs/update-readme-with-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 *Changelog created using the [Simple Changelog](https://marketplace.visualstudio.com/items?itemName=tobiaswaelde.vscode-simple-changelog) extension for VS Code.*
 
+## [1.0.2] - 2024-12-24
+### Added
+- Add Example section in README.md
+
+
 ## [1.0.0] - 2024-12-21
 ### Added
 - Created README.md and tasks files

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
 
 - [🏁 Getting Started](#-getting-started)
 - [🎈 Usage](#-usage)
-- [Options](#options)
+- [:gear: Options](#gear-options)
+- [:exclamation: Example](#exclamation-example)
 - [⛏️ Built Using](#️-built-using)
 - [🤝 Contributing](#-contributing)
 - [💖 Show your support](#-show-your-support)
@@ -81,9 +82,149 @@ generate-cli-markdown: {
 }
 ```
 
-## Options
+## :gear: Options
 
 - `cliPath` **(required)**: The path to the executable file of your CLI tool. (Type: String)
+
+## :exclamation: Example
+
+This example demonstrates how to use `grunt-generate-cli-markdown` with a simple CLI that has two commands (`check` and `build`) and a global verbose option.  It also showcases the use of command aliases and customizing the help output.
+
+**1. Create the CLI:**
+
+Create a file named `src/index.js` (or any name you like, making sure to update the paths in the configuration accordingly) with the following content:
+
+```javascript
+#!/usr/bin/env node
+const { program } = require('commander');
+
+program
+  .version('1.0.0')
+  .option('-v, --verbose', 'Enable verbose output')
+  .configureHelp({
+    sortCommands: true,
+    sortOptions: true,
+    showGlobalOptions: true
+  });
+
+
+program
+  .command('check', { hidden: false })
+  .alias('c')
+  .description('Check the project')
+  .action(() => {
+    console.log('Checking the project...');
+  });
+
+program
+  .command('build', { hidden: false })
+  .alias('b')
+  .description('Build the project')
+  .action(() => {
+    console.log('Building the project...');
+  });
+
+program.parse();
+
+```
+
+**2. Create a Gruntfile.js:**
+
+Create a file named `Gruntfile.js` with the following content:
+
+```javascript
+module.exports = function(grunt) {
+  grunt.initConfig({
+    generate-cli-markdown: {
+      myTarget: {
+        options: {
+          cliPath: './src/index.js', // Path to your CLI
+        },
+        files: {
+          'docs/README.md': 'templates/README.md' // Source and destination for the markdown
+        }
+      }
+    }
+  })
+
+  grunt.loadNpmTasks('grunt-generate-cli-markdown');
+ 
+}
+```
+
+**3. Install dependencies:**
+
+- Install the `commander` package:
+
+```bash shell
+npm install commander
+```
+
+- Install the `grunt-generate-cli-markdown` and `grunt` packages:
+
+```bash shell
+npm install grunt-generate-cli-markdown --save-dev
+```
+
+**4. Install the Grunt-CLI package:**
+
+```bash shell
+npm install -g grunt-cli
+```
+
+**5. Run the Grunt task:** 
+
+```bash shell
+grunt
+```
+
+This will generate a markdown file (`docs/README.md` in this example) containing the documentation for your CLI, including the commands, their descriptions, aliases, and the global verbose option. The generated markdown will also reflect the custom help configuration using `sortCommands`, `sortOptions`, and `showGlobalOptions`.
+
+By modifying the `src/index.js` file (adding, removing, or changing commands, options, descriptions, etc.), and re-running the grunt `generate-cli-markdown` task, the generated markdown documentation will automatically update to reflect the changes in your CLI's source code. For instance, adding a new command with its description and options in `src/index.js` will result in this new command's documentation appearing in the generated markdown after running the Grunt task.
+
+**6. Exammine the generated markdown:**
+
+```markdown
+# My CLI Tool
+
+```
+
+**7. Change CLI source file:**
+
+Update the CLI source file to include more commands, options, and aliases. Rerun the Grunt task to generate the updated markdown.
+
+```javascript
+program
+  .command('check', { hidden: false })
+  .alias('c')
+  .description('Check the project')
+  .action(() => {
+    console.log('Checking the project...');
+  });
+
+program
+  .command('build', { hidden: false })
+  .alias('b')
+  .description('Build the project')
+  .action(() => {
+    console.log('Building the project...');
+  });
+
+program
+  .command('deploy', { hidden: false })
+  .alias('d')
+  .description('Deploy the project')
+  .action(() => {
+    console.log('Deploying the project...');
+  });
+
+program.parse();
+```
+
+```bash shell
+grunt generate-cli-markdown
+```
+```
 
 ## ⛏️ Built Using
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grunt-generate-cli-markdown",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grunt-generate-cli-markdown",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "child-process": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grunt-generate-cli-markdown",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grunt-generate-cli-markdown",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "child-process": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-generate-cli-markdown",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "tasks/generate-cli-markdown.js",
   "scripts": {
     "test": "jest --passWithNoTests"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-generate-cli-markdown",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "tasks/generate-cli-markdown.js",
   "scripts": {
     "test": "jest --passWithNoTests"


### PR DESCRIPTION
* feat(CHANGELOG.md): add Example section in README.md

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an Example section to the README.md to guide users through setting up and using the `grunt-generate-cli-markdown` tool, update version in `package.json` to 1.0.2, and include these updates in the CHANGELOG.md.

### Why are these changes being made?

Providing an example in the README.md helps users understand how to properly implement the `grunt-generate-cli-markdown` tool in their projects, enhancing the documentation. The version bump to 1.0.2 and corresponding changelog update reflect the addition of this new documentation feature.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->